### PR TITLE
Add Setting to Fail Check if no Matching AMI Found

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ A Concourse resource for tracking AMI versions
 
 * `secret_access_key`: *Required.* The AWS secret key to use.
 
-* `region`: *Required* the AWS region the AMIs are located in.
+* `region`: *Required.* the AWS region the AMIs are located in.
+
+* `allow_no_matches`: *Optional.* Default `true`.  A boolean that specifies if the check should succeed in the case where no AMI is found that matches the search options.
+  * `true` - Always succeed even if no matching AMI is found.
+  * `false` - Fail if no matching AMI is found.
 
 * `search_options`: Options to filter AMIs, see [supported options](http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#describe_images-instance_method).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AMI Resource
 
-A Concourse resource for tracking AMI versions
+A Concourse resource for tracking AMI versions.  This is a **get only** resource.
 
 ## Source Configuration
 

--- a/bin/check
+++ b/bin/check
@@ -11,6 +11,7 @@ access_key = source.fetch("access_key_id")
 secret_key = source.fetch("secret_access_key")
 region = source.fetch("region")
 options = source.fetch("search_options")
+allow_no_matches = source.fetch("allow_no_matches", true).to_s
 
 version = nil
 first_request = true
@@ -43,5 +44,10 @@ else
 end
 
 puts JSON.generate(result.map do |image_id|
-	{ref: image_id}
+	if allow_no_matches == "false" and image_id.nil?
+		$stderr.puts "No matching AMIs were found"
+		exit(1)
+	else
+		{ref: image_id}
+	end
 end)


### PR DESCRIPTION
Added a setting to fail the check if no matching ami is found.  This setting is optional and defaults to `true` which corresponds with current behavior thus making this change completely backwards compatible.